### PR TITLE
Fix lint issues in bot package

### DIFF
--- a/bot/config_reload.py
+++ b/bot/config_reload.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Dict, Any, Optional, Set, Callable, List
 from datetime import datetime
 from dotenv import load_dotenv
-import os
 
 from .config import load_config
 from .utils.logging import get_logger

--- a/bot/core/bot.py
+++ b/bot/core/bot.py
@@ -27,7 +27,6 @@ from bot.voice import VoiceMessagePublisher
 from bot.memory.thread_tail import (
     resolve_thread_reply_target,
     _is_thread_channel,
-    resolve_implicit_anchor,
 )
 
 if TYPE_CHECKING:
@@ -1278,14 +1277,12 @@ class LLMBot(commands.Bot):
 
                     # Decide ping mode
                     ping_mode = "none"
-                    reply_ping = False
                     explicit_mention = False
                     try:
                         if recipient is not None:
                             # Preferred: rely on reply ping when the target author is the human recipient
                             if reply_target is not None and getattr(reply_target, "author", None) is recipient and not getattr(recipient, "bot", False):
                                 ping_mode = "reply_ping"
-                                reply_ping = True
                             else:
                                 # Use explicit mention when target author is a bot or different; avoid double-ping
                                 ping_mode = "explicit_mention"
@@ -1294,7 +1291,6 @@ class LLMBot(commands.Bot):
                             ping_mode = "none"
                     except Exception:
                         ping_mode = "none"
-                        reply_ping = False
                         explicit_mention = False
 
                     # Build AllowedMentions whitelist to enforce single notification path

--- a/bot/evidence.py
+++ b/bot/evidence.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def _normalize_text(value: Optional[str]) -> str:

--- a/bot/memory/mention_context.py
+++ b/bot/memory/mention_context.py
@@ -90,13 +90,12 @@ async def resolve_anchor(message: discord.Message, case: str, timeout_s: float) 
         # Best-effort: earliest message in the thread (acts as thread starter)
         try:
             hist = message.channel.history(limit=200, oldest_first=True)
-            # Guard the first fetch with timeout
-            first: Optional[discord.Message] = None
+
             async def _first() -> Optional[discord.Message]:
                 async for m in hist:
-                    first = m
-                    return first
+                    return m
                 return None
+
             return await asyncio.wait_for(_first(), timeout=timeout_s)
         except Exception:
             return None

--- a/bot/memory/thread_tail.py
+++ b/bot/memory/thread_tail.py
@@ -293,9 +293,6 @@ async def collect_thread_tail_context(
         if not _is_thread_channel(ch):
             return None
 
-        # Hard-enabled per design: always on in thread channels
-        enabled = True
-
         try:
             k = int(cfg.get("THREAD_CONTEXT_TAIL_COUNT", 5))
         except Exception:

--- a/bot/router.py
+++ b/bot/router.py
@@ -28,7 +28,17 @@ from enum import Enum, auto
 from html import unescape
 import json
 from pathlib import Path
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Any
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+)
 from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse, unquote
 
 import discord
@@ -1463,7 +1473,8 @@ class Router:
                     host = (pu.netloc or "").lower()
                     path = (pu.path or "").lower()
                 except Exception:
-                    host = ""; path = ""
+                    host = ""
+                    path = ""
                 # Detect video poster thumbs from pbs
                 if host.endswith("pbs.twimg.com") and any(pref in path for pref in poster_prefixes):
                     poster_detected_global = True
@@ -1798,7 +1809,8 @@ class Router:
                             host = (pu.netloc or "").lower()
                             path = (pu.path or "").lower()
                         except Exception:
-                            host = ""; path = ""
+                            host = ""
+                            path = ""
                         poster_prefixes = (
                             "/amplify_video_thumb/",
                             "/ext_tw_video_thumb/",
@@ -2013,7 +2025,9 @@ class Router:
                 return await self._process_image_from_url(
                     url, model_override=model_override
                 )
-                                
+
+            if item.source_type == "embed":
+                embed = item.payload
                 image_url = None
                 try:
                     if isinstance(embed, dict):
@@ -4955,6 +4969,8 @@ class Router:
             except Exception:
                 web_extract_timeout = 30.0
 
+            api_data: Optional[Dict[str, Any]] = None
+
             async def _bounded(coro, timeout_s: float, tag: str, detail: Optional[dict] = None):
                 """Await coro with a timeout and emit start/ok/timeout/fail breadcrumbs. [REH][PA]"""
                 import time as _t
@@ -6608,10 +6624,17 @@ class Router:
                 if anchored_system and contradicts:
                     # Try one more time with a tighter instruction
                     try:
+                        repair_prompt = (
+                            (content_str or "")
+                            + "\n\n"  # Preserve original prompt context.
+                            + (
+                                "The previous draft incorrectly implied there was no image. "
+                                "Respect the provided visual facts (including any VL prompt output) and answer accordingly."
+                            )
+                        )
                         second = await contextual_brain_infer_simple(
-                            repair_instr,
                             message,
-                            content_str,
+                            repair_prompt,
                             self.bot,
                             perception_notes=perception_notes,
                             extra_context=enhanced_context,
@@ -7326,10 +7349,11 @@ class Router:
             # Extract tweet metadata for provenance
             user = syn_data.get("user") or {}
             username = user.get("screen_name") or user.get("name") or "unknown"
-            created_at = syn_data.get("created_at")
+            created_at = syn_data.get("created_at") or "unknown"
 
             self.logger.info(
                 f"🖼️ Processing {len(photos)} image(s) from image-only tweet: {url}"
+                f" | author={username} | created_at={created_at}"
             )
             self._metric_inc(
                 "vision.image_only_tweet.start",


### PR DESCRIPTION
## Summary
- remove unused imports and dead assignments flagged by ruff across bot configuration and memory helpers
- harden the router image handling by splitting embed processing, logging provenance metadata, and ensuring helper variables are initialized
- adjust contextual brain fallback prompt construction to avoid undefined names and keep retry behaviour intact

## Testing
- ruff check bot/
- pytest bot/


------
https://chatgpt.com/codex/tasks/task_e_68ec842826bc8325a6b6d6441b839161